### PR TITLE
feat: Include type in node identity

### DIFF
--- a/knowledge_graph/__init__.py
+++ b/knowledge_graph/__init__.py
@@ -1,3 +1,5 @@
 from .cassandra_graph_store import CassandraGraphStore
+from .runnables import extract_entities
+from .traverse import Node, Relation
 
-__all__ = ["CassandraGraphStore"]
+__all__ = ["CassandraGraphStore", "extract_entities", "Node", "Relation"]

--- a/knowledge_graph/cassandra_graph_store.py
+++ b/knowledge_graph/cassandra_graph_store.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
 from cassandra.cluster import Session
 from cassandra.query import BatchStatement, PreparedStatement
@@ -34,34 +34,50 @@ class CassandraGraphStore(GraphStore):
         self._node_table = node_table
         self._edge_table = edge_table
 
-        self._session.set_keyspace(keyspace)
+        # Partition by `name` and cluster by `type`.
+        # Each `(name, type)` pair is a unique node.
+        # We can enumerate all `type` values for a given `name` to identify ambiguous terms.
         self._session.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {node_table} (
-                id TEXT,
+            CREATE TABLE IF NOT EXISTS {keyspace}.{node_table} (
+                name TEXT,
                 type TEXT,
-                PRIMARY KEY (id, type)
+                PRIMARY KEY (name, type)
             );
             """
         )
 
         self._session.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {edge_table} (
-                source TEXT,
-                target TEXT,
-                type TEXT,
-                PRIMARY KEY (source, target, type)
+            CREATE TABLE IF NOT EXISTS {keyspace}.{edge_table} (
+                source_name TEXT,
+                source_type TEXT,
+                target_name TEXT,
+                target_type TEXT,
+                edge_type TEXT,
+                PRIMARY KEY ((source_name, source_type), target_name, target_type, edge_type)
             );
+            """
+        )
+
+        self._session.execute(
+            f"""
+            CREATE CUSTOM INDEX {edge_table}_type_index
+            ON {keyspace}.{edge_table} (edge_type)
+            USING 'StorageAttachedIndex';
             """
         )
 
         self._insert_node = self._session.prepare(
-            f"INSERT INTO {node_table} (id, type) VALUES (?, ?)"
+            f"INSERT INTO {keyspace}.{node_table} (name, type) VALUES (?, ?)"
         )
 
         self._insert_relationship = self._session.prepare(
-            f"INSERT INTO {edge_table} (source, target, type) VALUES (?, ?, ?)"
+            f"""
+            INSERT INTO {keyspace}.{edge_table} (
+                source_name, source_type, target_name, target_type, edge_type
+            ) VALUES (?, ?, ?, ?, ?)
+            """
         )
 
     def add_graph_documents(
@@ -86,7 +102,13 @@ class CassandraGraphStore(GraphStore):
             for edge in graph_document.relationships:
                 yield (
                     self._insert_relationship,
-                    (edge.source.id, edge.target.id, edge.type),
+                    (
+                        edge.source.id,
+                        edge.source.type,
+                        edge.target.id,
+                        edge.target.type,
+                        edge.type,
+                    ),
                 )
 
     # TODO: should this include the types of each node?
@@ -95,16 +117,18 @@ class CassandraGraphStore(GraphStore):
 
         return self.as_runnable(steps=steps).invoke(query)
 
-    def as_runnable(self, steps: int = 3) -> Runnable:
+    def as_runnable(self, steps: int = 3, edge_filters: Sequence[str] = []) -> Runnable:
         """
-        Return a retriever that queries this graph store for the entity or entities specified.
+        Return a runnable that retrieves the sub-graph near the input entity or entities.
 
         Parameters:
         - steps: The maximum distance to follow from the starting points.
+        - edge_filters: Predicates to use for filtering the edges.
         """
         return RunnableLambda(func=traverse, afunc=atraverse).bind(
             edge_table=self._edge_table,
             steps=steps,
             session=self._session,
             keyspace=self._keyspace,
+            edge_filters=edge_filters,
         )

--- a/knowledge_graph/runnables.py
+++ b/knowledge_graph/runnables.py
@@ -1,0 +1,64 @@
+from typing import List, Optional
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.pydantic_v1 import BaseModel, Field
+from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
+from langchain_experimental.graph_transformers.llm import optional_enum_field
+
+from .traverse import Node
+
+QUERY_KEYWORD_EXTRACT_PROMPT = (
+    "A question is provided below. Given the question, extract up to 5 "
+    "keywords from the text. Focus on extracting the keywords that we can use "
+    "to best lookup answers to the question. Avoid stopwords.\n"
+    "---------------------\n"
+    "{question}\n"
+    "---------------------\n"
+    "{format_instructions}\n"
+)
+
+
+def extract_entities(
+    llm: BaseChatModel,
+    keyword_extraction_prompt: str = QUERY_KEYWORD_EXTRACT_PROMPT,
+    node_types: Optional[List[str]] = None,
+) -> Runnable:
+    """
+    Return a keyword-extraction runnable.
+
+    This will expect a dictionary containing the `"question"` to extract keywords from.
+
+    Parameters:
+    - llm: The LLM to use for extracting entities.
+    - node_types: List of node types to extract.
+    - keyword_extraction_prompt: The prompt to use for requesting entities.
+      This should include the `{question}` being asked as well as the `{format_instructions}`
+      which describe how to produce the output.
+    """
+    prompt = ChatPromptTemplate.from_messages([keyword_extraction_prompt])
+    assert "question" in prompt.input_variables
+    assert "format_instructions" in prompt.input_variables
+
+    class SimpleNode(BaseModel):
+        """Represents a node in a graph with associated properties."""
+
+        id: str = Field(description="Name or human-readable unique identifier.")
+        type: str = optional_enum_field(node_types, description="The type or label of the node.")
+
+    class SimpleNodeList(BaseModel):
+        """Represents a list of simple nodes."""
+
+        nodes: List[SimpleNode]
+
+    output_parser = JsonOutputParser(pydantic_object=SimpleNodeList)
+    return (
+        RunnablePassthrough.assign(
+            format_instructions=lambda _: output_parser.get_format_instructions(),
+        )
+        | ChatPromptTemplate.from_messages([keyword_extraction_prompt])
+        | llm
+        | output_parser
+        | RunnableLambda(lambda node_list: [Node(n["id"], n["type"]) for n in node_list["nodes"]])
+    )

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -12,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -21,7 +30,7 @@
        "True"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -33,28 +42,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['ASTRA_DB_DATABASE_ID', 'ASTRA_DB_APPLICATION_TOKEN']"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
-    "[k for k in os.environ.keys() if k.startswith(\"ASTRA\")]"
+    "import cassio\n",
+    "cassio.init(auto=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -127,11 +125,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
+    "# Save the extracted graph documents to the Cassandra Graph Store.\n",
     "graph_store.add_graph_documents(graph_documents)"
    ]
   },
@@ -162,118 +160,84 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Querying"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{Marie Curie -> Chemist: HAS_PROFESSION,\n",
-       " Marie Curie -> French: HAS_NATIONALITY,\n",
-       " Marie Curie -> Nobel Prize: WON,\n",
-       " Marie Curie -> Physicist: HAS_PROFESSION,\n",
-       " Marie Curie -> Pierre Curie: MARRIED_TO,\n",
-       " Marie Curie -> Polish: HAS_NATIONALITY,\n",
-       " Marie Curie -> Professor: HAS_PROFESSION,\n",
-       " Marie Curie -> Radioactivity: RESEARCHED,\n",
-       " Marie Curie -> University Of Paris: WORKED_AT,\n",
-       " Pierre Curie -> Nobel Prize: WON}"
+       "{Marie Curie(Person) -> Chemist(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> French(Nationality): HAS_NATIONALITY,\n",
+       " Marie Curie(Person) -> Nobel Prize(Award): WON,\n",
+       " Marie Curie(Person) -> Physicist(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> Pierre Curie(Person): MARRIED_TO,\n",
+       " Marie Curie(Person) -> Polish(Nationality): HAS_NATIONALITY,\n",
+       " Marie Curie(Person) -> Professor(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> Radioactivity(Scientific concept): RESEARCHED,\n",
+       " Marie Curie(Person) -> University Of Paris(Organization): WORKED_AT,\n",
+       " Pierre Curie(Person) -> Nobel Prize(Award): WON}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "graph_store.query(\"Marie Curie\", {})"
+    "from knowledge_graph.traverse import Node\n",
+    "\n",
+    "graph_store.as_runnable(steps=2).invoke(Node(\"Marie Curie\", \"Person\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain_openai import ChatOpenAI\n",
-    "llm = ChatOpenAI(model_name = \"gpt-4\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "QUERY_KEYWORD_EXTRACT_PROMPT = (\n",
-    "    \"A question is provided below. Given the question, extract up to 5 \"\n",
-    "    \"keywords from the text. Focus on extracting the keywords that we can use \"\n",
-    "    \"to best lookup answers to the question. Avoid stopwords.\\n\"\n",
-    "    \"---------------------\\n\"\n",
-    "    \"{question}\\n\"\n",
-    "    \"---------------------\\n\"\n",
-    "    \"Provide keywords as a JSON list.\\n\"\n",
-    ")\n",
-    "\n",
-    "from langchain_core.runnables import RunnablePassthrough\n",
-    "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_core.output_parsers import JsonOutputParser\n",
-    "\n",
-    "keywords_chain = (\n",
-    "    ChatPromptTemplate.from_messages([QUERY_KEYWORD_EXTRACT_PROMPT])\n",
-    "    | llm\n",
-    "    | JsonOutputParser()\n",
-    ")\n",
-    "\n",
-    "query_keyword_extraction = (\n",
-    "    { \"question\": RunnablePassthrough() }\n",
-    "    | keywords_chain\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Marie Curie']"
+       "{Marie Curie(Person) -> Chemist(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> French(Nationality): HAS_NATIONALITY,\n",
+       " Marie Curie(Person) -> Nobel Prize(Award): WON,\n",
+       " Marie Curie(Person) -> Physicist(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> Pierre Curie(Person): MARRIED_TO,\n",
+       " Marie Curie(Person) -> Polish(Nationality): HAS_NATIONALITY,\n",
+       " Marie Curie(Person) -> Professor(Profession): HAS_PROFESSION,\n",
+       " Marie Curie(Person) -> Radioactivity(Scientific concept): RESEARCHED,\n",
+       " Marie Curie(Person) -> University Of Paris(Organization): WORKED_AT,\n",
+       " Pierre Curie(Person) -> Nobel Prize(Award): WON}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "query_keyword_extraction.invoke(\"Who is Marie Curie?\")"
+    "await graph_store.as_runnable(steps=2).ainvoke(Node(\"Marie Curie\", \"Person\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
     "from operator import itemgetter\n",
-    "from langchain_core.runnables import RunnableLambda\n",
+    "from langchain_core.runnables import RunnableLambda, RunnablePassthrough\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from knowledge_graph import extract_entities\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "llm = ChatOpenAI(model_name = \"gpt-4\")\n",
     "\n",
-    "def _combine_triples(triple_strs):\n",
-    "    return \"\\n\".join(map(repr, triple_strs))\n",
+    "def _combine_relations(relations):\n",
+    "    return \"\\n\".join(map(repr, relations))\n",
     "\n",
     "ANSWER_PROMPT = (\n",
     "    \"The original question is given below.\"\n",
@@ -287,9 +251,9 @@
     "\n",
     "chain = (\n",
     "    { \"question\": RunnablePassthrough() }\n",
-    "    | RunnablePassthrough.assign(keywords = keywords_chain)\n",
-    "    | RunnablePassthrough.assign(triples = itemgetter(\"keywords\") | graph_store.as_runnable())\n",
-    "    | RunnablePassthrough.assign(context = itemgetter(\"triples\") | RunnableLambda(_combine_triples))\n",
+    "    | RunnablePassthrough.assign(entities = extract_entities(llm))\n",
+    "    | RunnablePassthrough.assign(triples = itemgetter(\"entities\") | graph_store.as_runnable())\n",
+    "    | RunnablePassthrough.assign(context = itemgetter(\"triples\") | RunnableLambda(_combine_relations))\n",
     "    | ChatPromptTemplate.from_messages([ANSWER_PROMPT])\n",
     "    | llm\n",
     ")"
@@ -297,16 +261,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='Marie Curie was a chemist, physicist, and professor who researched radioactivity. She worked at the University of Paris. She was Polish and French by nationality and was married to Pierre Curie. Both she and Pierre Curie won the Nobel Prize.', response_metadata={'token_usage': {'completion_tokens': 52, 'prompt_tokens': 181, 'total_tokens': 233}, 'model_name': 'gpt-4', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None})"
+       "AIMessage(content='Marie Curie is a Polish-French physicist, chemist, and professor who researched radioactivity. She worked at the University of Paris and is married to Pierre Curie. Both she and her husband have won the Nobel Prize.', response_metadata={'token_usage': {'completion_tokens': 47, 'prompt_tokens': 227, 'total_tokens': 274}, 'model_name': 'gpt-4', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-92c5ca1b-2676-4c3b-a4be-444036ad34f2-0')"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tests/test_runnables.py
+++ b/tests/test_runnables.py
@@ -1,0 +1,12 @@
+from precisely import assert_that, contains_exactly
+
+from knowledge_graph.runnables import extract_entities
+from knowledge_graph.traverse import Node
+
+
+def test_extract_entities(llm):
+    extractor = extract_entities(llm)
+    assert_that(
+        extractor.invoke({"question": "Who is Marie Curie?"}),
+        contains_exactly(Node("Marie Curie", "Person")),
+    )

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1,102 +1,125 @@
 from precisely import assert_that, contains_exactly
-import pytest
 
-from knowledge_graph.traverse import Relation, atraverse, traverse
+from knowledge_graph.traverse import Node, Relation, atraverse, traverse
 
 from .conftest import DataFixture
 
 
 def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     results = traverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=1,
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation("Marie Curie", "Polish", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "French", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "Physicist", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Chemist", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Professor", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Radioactivity", "RESEARCHED"),
-        Relation("Marie Curie", "Nobel Prize", "WON"),
-        Relation("Marie Curie", "Pierre Curie", "MARRIED_TO"),
-        Relation("Marie Curie", "University of Paris", "WORKED_AT"),
+        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Physicist", "Profession"), "HAS_PROFESSION"
+        ),
+        Relation(Node("Marie Curie", "Person"), Node("Chemist", "Profession"), "HAS_PROFESSION"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Professor", "Profession"), "HAS_PROFESSION"
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Radioactivity", "Scientific concept"),
+            "RESEARCHED",
+        ),
+        Relation(Node("Marie Curie", "Person"), Node("Nobel Prize", "Award"), "WON"),
+        Relation(Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("University of Paris", "Organization"),
+            "WORKED_AT",
+        ),
     }
     assert_that(results, contains_exactly(*expected))
 
     results = traverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=2,
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    expected.add(Relation("Pierre Curie", "Nobel Prize", "WON"))
+    expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
     assert_that(results, contains_exactly(*expected))
 
 
 async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
     results = await atraverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=1,
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation("Marie Curie", "Polish", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "French", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "Physicist", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Chemist", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Professor", "HAS_PROFESSION"),
-        Relation("Marie Curie", "Radioactivity", "RESEARCHED"),
-        Relation("Marie Curie", "Nobel Prize", "WON"),
-        Relation("Marie Curie", "Pierre Curie", "MARRIED_TO"),
-        Relation("Marie Curie", "University of Paris", "WORKED_AT"),
+        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Physicist", "Profession"), "HAS_PROFESSION"
+        ),
+        Relation(Node("Marie Curie", "Person"), Node("Chemist", "Profession"), "HAS_PROFESSION"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Professor", "Profession"), "HAS_PROFESSION"
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Radioactivity", "Scientific concept"),
+            "RESEARCHED",
+        ),
+        Relation(Node("Marie Curie", "Person"), Node("Nobel Prize", "Award"), "WON"),
+        Relation(Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("University of Paris", "Organization"),
+            "WORKED_AT",
+        ),
     }
     assert_that(results, contains_exactly(*expected))
 
     results = await atraverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=2,
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    expected.add(Relation("Pierre Curie", "Nobel Prize", "WON"))
+    expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
     assert_that(results, contains_exactly(*expected))
 
-@pytest.mark.skip("filtering not yet supported")
+
 def test_traverse_marie_curie_filtered_edges(marie_curie: DataFixture) -> None:
     results = traverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=1,
-        edge_filters=["type = 'HAS_NATIONALITY'"],
+        edge_filters=["edge_type = 'HAS_NATIONALITY'"],
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation("Marie Curie", "Polish", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "French", "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
     }
     assert_that(results, contains_exactly(*expected))
 
-@pytest.mark.skip("filtering not yet supported")
+
 async def test_atraverse_marie_curie_filtered_edges(marie_curie: DataFixture) -> None:
     results = await atraverse(
-        "Marie Curie",
+        start=Node("Marie Curie", "Person"),
         steps=1,
-        edge_filters=["type = 'HAS_NATIONALITY'"],
+        edge_filters=["edge_type = 'HAS_NATIONALITY'"],
         edge_table=marie_curie.edge_table,
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation("Marie Curie", "Polish", "HAS_NATIONALITY"),
-        Relation("Marie Curie", "French", "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
+        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
     }
     assert_that(results, contains_exactly(*expected))


### PR DESCRIPTION
This required changing the `source IN (...)` query to use a bunch of `source_name = ? AND source_type = ?` queries in parallel.

- Include node type in the source/target of each edge.
- Support querying based on specific types.