### PR TITLE
feat: Introduce Knowledge schemas

### DIFF
--- a/knowledge_graph/__init__.py
+++ b/knowledge_graph/__init__.py
@@ -2,5 +2,4 @@ from .cassandra_graph_store import CassandraGraphStore
 from .runnables import extract_entities
 from .traverse import Node, Relation
 
-__all__ = [
-    "CassandraGraphStore", "extract_entities", "Node", "Relation"           ]
+__all__ = ["CassandraGraphStore", "extract_entities", "Node", "Relation"]

--- a/knowledge_graph/__init__.py
+++ b/knowledge_graph/__init__.py
@@ -2,4 +2,5 @@ from .cassandra_graph_store import CassandraGraphStore
 from .runnables import extract_entities
 from .traverse import Node, Relation
 
-__all__ = ["CassandraGraphStore", "extract_entities", "Node", "Relation"]
+__all__ = [
+    "CassandraGraphStore", "extract_entities", "Node", "Relation"           ]

--- a/knowledge_graph/cassandra_graph_store.py
+++ b/knowledge_graph/cassandra_graph_store.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 from cassandra.cluster import Session
 from langchain_community.graphs.graph_document import GraphDocument
@@ -10,14 +10,18 @@ from knowledge_graph.knowledge_graph import CassandraKnowledgeGraph
 
 from .traverse import Node, Relation
 
+
 def _elements(documents: Iterable[GraphDocument]) -> Iterable[Union[Node, Relation]]:
     def _node(node: LangChainNode) -> Node:
         return Node(name=str(node.id), type=node.type)
+
     for document in documents:
         for node in document.nodes:
             yield _node(node)
         for edge in document.relationships:
             yield Relation(source=_node(edge.source), target=_node(edge.target), type=edge.type)
+
+
 class CassandraGraphStore(GraphStore):
     def __init__(
         self,
@@ -33,23 +37,21 @@ class CassandraGraphStore(GraphStore):
         provide valid session and keyspace values.
         """
         self._graph = CassandraKnowledgeGraph(
-            node_table = node_table,
-            edge_table = edge_table,
-            session = session,
-            keyspace = keyspace,
+            node_table=node_table,
+            edge_table=edge_table,
+            session=session,
+            keyspace=keyspace,
         )
 
     def add_graph_documents(
         self, graph_documents: List[GraphDocument], include_source: bool = False
     ) -> None:
         # TODO: Include source.
-        self._graph.insert(
-            _elements(graph_documents)
-        )
+        self._graph.insert(_elements(graph_documents))
 
     # TODO: should this include the types of each node?
     def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
-        raise ValueError(f"Querying Cassandra should use `as_runnable`.")
+        raise ValueError("Querying Cassandra should use `as_runnable`.")
 
     def as_runnable(self, steps: int = 3, edge_filters: Sequence[str] = []) -> Runnable:
         """

--- a/knowledge_graph/extraction.py
+++ b/knowledge_graph/extraction.py
@@ -1,14 +1,25 @@
 from os import path
-from typing import Dict, Iterable, List, Sequence, Union, cast
-from langchain_core.pydantic_v1 import BaseModel
-from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, PromptTemplate
-from langchain_core.documents import Document
+from typing import Dict, List, Sequence, Union, cast
 
 from langchain_community.graphs.graph_document import GraphDocument
-from langchain_experimental.graph_transformers.llm import create_simple_model, _Graph, map_to_base_node, map_to_base_relationship
+from langchain_core.documents import Document
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    PromptTemplate,
+    SystemMessagePromptTemplate,
+)
+from langchain_core.pydantic_v1 import BaseModel
+from langchain_experimental.graph_transformers.llm import (
+    _Graph,
+    create_simple_model,
+    map_to_base_node,
+    map_to_base_relationship,
+)
 
 from knowledge_graph.traverse import Node, Relation
+
 
 class NodeSchema(BaseModel):
     type: str
@@ -17,12 +28,14 @@ class NodeSchema(BaseModel):
     description: str
     """Description of the node type."""
 
+
 class EdgeSchema(BaseModel):
     type: str
     """The name of the edge type."""
 
     description: str
     """Description of the edge type."""
+
 
 class RelationshipSchema(BaseModel):
     edge_type: str
@@ -37,6 +50,7 @@ class RelationshipSchema(BaseModel):
     description: str
     """Description of the relationship."""
 
+
 class Example(BaseModel):
     input: str
     """The source input."""
@@ -46,6 +60,7 @@ class Example(BaseModel):
 
     edges: Sequence[Relation]
     """The extracted example relationhsips."""
+
 
 class KnowledgeSchema(BaseModel):
     nodes: List[NodeSchema]
@@ -57,18 +72,19 @@ class KnowledgeSchema(BaseModel):
     examples: List[Example] = []
     """Example extractions."""
 
-class KnowledgeSchemaValidator():
+
+class KnowledgeSchemaValidator:
     def __init__(self, schema: KnowledgeSchema) -> None:
         self._schema = schema
 
-        self._nodes = { node.type: node for node in schema.nodes }
+        self._nodes = {node.type: node for node in schema.nodes}
 
         self._relationships: Dict[str, List[RelationshipSchema]] = {}
         for r in schema.relationships:
-             self._relationships.setdefault(r.edge_type, []).append(r)
+            self._relationships.setdefault(r.edge_type, []).append(r)
 
-             # TODO: Validate the relationship.
-             # source/target type should exist in nodes, edge_type should exist in edges
+            # TODO: Validate the relationship.
+            # source/target type should exist in nodes, edge_type should exist in edges
 
     def validate_graph_document(self, document: GraphDocument):
         e = ValueError("Invalid graph document for schema")
@@ -80,36 +96,49 @@ class KnowledgeSchemaValidator():
             if relationships is None:
                 e.add_note(f"No edge type '{r.edge_type}")
             else:
-                relationship = next((candidate for candidate in relationships
-                                     if r.source_type in candidate.source_types
-                                     if r.target_type in candidate.target_types))
+                relationship = next(
+                    (
+                        candidate
+                        for candidate in relationships
+                        if r.source_type in candidate.source_types
+                        if r.target_type in candidate.target_types
+                    )
+                )
                 if relationship is None:
-                    e.add_note(f"No relationship allows ({r.source_id} -> {r.type} -> {r.target.type})")
+                    e.add_note(
+                        f"No relationship allows ({r.source_id} -> {r.type} -> {r.target.type})"
+                    )
 
         if e.__notes__:
             raise e
 
 
-TEMPLATE_PATH = path.join(path.dirname(__file__), 'prompt_templates')
+TEMPLATE_PATH = path.join(path.dirname(__file__), "prompt_templates")
+
 
 def _format_example(idx: int, example: Example) -> str:
     lines = [
-        f"Example {idx} Input: {example.input}\n"
-        f"Example {idx} Nodes: ",
+        f"Example {idx} Input: {example.input}\n" f"Example {idx} Nodes: ",
     ]
 
     def f_node(node: Node) -> str:
         return f"{{ name: {node.name}, type: {node.type} }}"
+
     lines.extend([f"- {f_node(node)}" for node in example.nodes])
     lines.append(f"Example {idx} Edges: ")
-    lines.extend([f"- {{ source: {f_node(edge.source)}, target: {f_node(edge.target)}, type: {edge.type} }}" for edge in example.edges])
+    lines.extend(
+        [
+            f"- {{ source: {f_node(e.source)}, target: {f_node(e.target)}, type: {e.type} }}"
+            for e in example.edges
+        ]
+    )
     return "\n".join(lines)
-
 
 
 def _extraction_prompt(schema: KnowledgeSchema) -> SystemMessagePromptTemplate:
     def fmt_node(node: NodeSchema) -> str:
         return f"- Node type {node.type}: {node.description}"
+
     def fmt_relationship(rel: RelationshipSchema) -> str:
         return (
             f"- Edge type {rel.edge_type}: {rel.description}\n"
@@ -121,18 +150,14 @@ def _extraction_prompt(schema: KnowledgeSchema) -> SystemMessagePromptTemplate:
     relationship_patterns = "\n".join(map(fmt_relationship, schema.relationships))
 
     return SystemMessagePromptTemplate(
-        prompt = PromptTemplate.from_file(path.join(TEMPLATE_PATH, "extraction.md")).partial(
-            node_types = node_types,
-            relationship_patterns = relationship_patterns
+        prompt=PromptTemplate.from_file(path.join(TEMPLATE_PATH, "extraction.md")).partial(
+            node_types=node_types, relationship_patterns=relationship_patterns
         )
     )
 
-class KnowledgeSchemaExtractor():
-    def __init__(self,
-                 llm: BaseChatModel,
-                 schema: KnowledgeSchema,
-                 strict: bool = False) -> None:
 
+class KnowledgeSchemaExtractor:
+    def __init__(self, llm: BaseChatModel, schema: KnowledgeSchema, strict: bool = False) -> None:
         self._validator = KnowledgeSchemaValidator(schema)
         self.strict = strict
 
@@ -140,38 +165,30 @@ class KnowledgeSchemaExtractor():
 
         if schema.examples:
             formatted = "\n\n".join(map(_format_example, schema.examples))
-            messages.append(SystemMessagePromptTemplate(prompt = formatted))
+            messages.append(SystemMessagePromptTemplate(prompt=formatted))
 
         messages.append(HumanMessagePromptTemplate.from_template("Input: {input}"))
 
         prompt = ChatPromptTemplate.from_messages(messages)
         schema = create_simple_model(
             node_labels=[node.type for node in schema.nodes],
-            rel_types=list({r.edge_type for r in schema.relationships})
+            rel_types=list({r.edge_type for r in schema.relationships}),
         )
         structured_llm = llm.with_structured_output(schema)
         self._chain = prompt | structured_llm
 
-    def _process_response(self,
-                          document: Document,
-                          response: Union[Dict, BaseModel]) -> GraphDocument:
+    def _process_response(
+        self, document: Document, response: Union[Dict, BaseModel]
+    ) -> GraphDocument:
         raw_graph = cast(_Graph, response)
-        nodes = (
-            [map_to_base_node(node) for node in raw_graph.nodes]
-            if raw_graph.nodes
-            else []
-        )
+        nodes = [map_to_base_node(node) for node in raw_graph.nodes] if raw_graph.nodes else []
         relationships = (
             [map_to_base_relationship(rel) for rel in raw_graph.relationships]
             if raw_graph.relationships
             else []
         )
 
-        document = GraphDocument(
-            nodes = nodes,
-            relationships = relationships,
-            source=document
-        )
+        document = GraphDocument(nodes=nodes, relationships=relationships, source=document)
 
         if self.strict:
             self._validator.validate_graph_document(document)
@@ -180,5 +197,7 @@ class KnowledgeSchemaExtractor():
 
     def extract(self, documents: List[Document]) -> List[GraphDocument]:
         # TODO: Define an async version of extraction?
-        responses = self._chain.batch_as_completed([{"input": doc.page_content} for doc in documents])
+        responses = self._chain.batch_as_completed(
+            [{"input": doc.page_content} for doc in documents]
+        )
         return [self._process_response(documents[idx], response) for idx, response in responses]

--- a/knowledge_graph/extraction.py
+++ b/knowledge_graph/extraction.py
@@ -1,0 +1,184 @@
+from os import path
+from typing import Dict, Iterable, List, Sequence, Union, cast
+from langchain_core.pydantic_v1 import BaseModel
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, PromptTemplate
+from langchain_core.documents import Document
+
+from langchain_community.graphs.graph_document import GraphDocument
+from langchain_experimental.graph_transformers.llm import create_simple_model, _Graph, map_to_base_node, map_to_base_relationship
+
+from knowledge_graph.traverse import Node, Relation
+
+class NodeSchema(BaseModel):
+    type: str
+    """The name of the node type."""
+
+    description: str
+    """Description of the node type."""
+
+class EdgeSchema(BaseModel):
+    type: str
+    """The name of the edge type."""
+
+    description: str
+    """Description of the edge type."""
+
+class RelationshipSchema(BaseModel):
+    edge_type: str
+    """The name of the edge type for the relationhsip."""
+
+    source_types: List[str]
+    """The node types for the source of the relationship."""
+
+    target_types: List[str]
+    """The node types for the target of the relationship."""
+
+    description: str
+    """Description of the relationship."""
+
+class Example(BaseModel):
+    input: str
+    """The source input."""
+
+    nodes: Sequence[Node]
+    """The extracted example nodes."""
+
+    edges: Sequence[Relation]
+    """The extracted example relationhsips."""
+
+class KnowledgeSchema(BaseModel):
+    nodes: List[NodeSchema]
+    """Allowed node types for the knowledge schema."""
+
+    relationships: List[RelationshipSchema]
+    """Allowed relationships for the knowledge schema."""
+
+    examples: List[Example] = []
+    """Example extractions."""
+
+class KnowledgeSchemaValidator():
+    def __init__(self, schema: KnowledgeSchema) -> None:
+        self._schema = schema
+
+        self._nodes = { node.type: node for node in schema.nodes }
+
+        self._relationships: Dict[str, List[RelationshipSchema]] = {}
+        for r in schema.relationships:
+             self._relationships.setdefault(r.edge_type, []).append(r)
+
+             # TODO: Validate the relationship.
+             # source/target type should exist in nodes, edge_type should exist in edges
+
+    def validate_graph_document(self, document: GraphDocument):
+        e = ValueError("Invalid graph document for schema")
+        for node_type in {node.type for node in document.nodes}:
+            if node_type not in self._nodes:
+                e.add_note(f"No node type '{node_type}")
+        for r in document.relationships:
+            relationships = self._relationships.get(r.edge_type, None)
+            if relationships is None:
+                e.add_note(f"No edge type '{r.edge_type}")
+            else:
+                relationship = next((candidate for candidate in relationships
+                                     if r.source_type in candidate.source_types
+                                     if r.target_type in candidate.target_types))
+                if relationship is None:
+                    e.add_note(f"No relationship allows ({r.source_id} -> {r.type} -> {r.target.type})")
+
+        if e.__notes__:
+            raise e
+
+
+TEMPLATE_PATH = path.join(path.dirname(__file__), 'prompt_templates')
+
+def _format_example(idx: int, example: Example) -> str:
+    lines = [
+        f"Example {idx} Input: {example.input}\n"
+        f"Example {idx} Nodes: ",
+    ]
+
+    def f_node(node: Node) -> str:
+        return f"{{ name: {node.name}, type: {node.type} }}"
+    lines.extend([f"- {f_node(node)}" for node in example.nodes])
+    lines.append(f"Example {idx} Edges: ")
+    lines.extend([f"- {{ source: {f_node(edge.source)}, target: {f_node(edge.target)}, type: {edge.type} }}" for edge in example.edges])
+    return "\n".join(lines)
+
+
+
+def _extraction_prompt(schema: KnowledgeSchema) -> SystemMessagePromptTemplate:
+    def fmt_node(node: NodeSchema) -> str:
+        return f"- Node type {node.type}: {node.description}"
+    def fmt_relationship(rel: RelationshipSchema) -> str:
+        return (
+            f"- Edge type {rel.edge_type}: {rel.description}\n"
+            f"  Source node types: {rel.source_types}\n"
+            f"  Target node types: {rel.target_types}\n"
+        )
+
+    node_types = "\n".join(map(fmt_node, schema.nodes))
+    relationship_patterns = "\n".join(map(fmt_relationship, schema.relationships))
+
+    return SystemMessagePromptTemplate(
+        prompt = PromptTemplate.from_file(path.join(TEMPLATE_PATH, "extraction.md")).partial(
+            node_types = node_types,
+            relationship_patterns = relationship_patterns
+        )
+    )
+
+class KnowledgeSchemaExtractor():
+    def __init__(self,
+                 llm: BaseChatModel,
+                 schema: KnowledgeSchema,
+                 strict: bool = False) -> None:
+
+        self._validator = KnowledgeSchemaValidator(schema)
+        self.strict = strict
+
+        messages = [_extraction_prompt(schema)]
+
+        if schema.examples:
+            formatted = "\n\n".join(map(_format_example, schema.examples))
+            messages.append(SystemMessagePromptTemplate(prompt = formatted))
+
+        messages.append(HumanMessagePromptTemplate.from_template("Input: {input}"))
+
+        prompt = ChatPromptTemplate.from_messages(messages)
+        schema = create_simple_model(
+            node_labels=[node.type for node in schema.nodes],
+            rel_types=list({r.edge_type for r in schema.relationships})
+        )
+        structured_llm = llm.with_structured_output(schema)
+        self._chain = prompt | structured_llm
+
+    def _process_response(self,
+                          document: Document,
+                          response: Union[Dict, BaseModel]) -> GraphDocument:
+        raw_graph = cast(_Graph, response)
+        nodes = (
+            [map_to_base_node(node) for node in raw_graph.nodes]
+            if raw_graph.nodes
+            else []
+        )
+        relationships = (
+            [map_to_base_relationship(rel) for rel in raw_graph.relationships]
+            if raw_graph.relationships
+            else []
+        )
+
+        document = GraphDocument(
+            nodes = nodes,
+            relationships = relationships,
+            source=document
+        )
+
+        if self.strict:
+            self._validator.validate_graph_document(document)
+
+        return document
+
+    def extract(self, documents: List[Document]) -> List[GraphDocument]:
+        # TODO: Define an async version of extraction?
+        responses = self._chain.batch_as_completed([{"input": doc.page_content} for doc in documents])
+        return [self._process_response(documents[idx], response) for idx, response in responses]

--- a/knowledge_graph/knowledge_graph.py
+++ b/knowledge_graph/knowledge_graph.py
@@ -4,17 +4,18 @@ from cassandra.cluster import Session
 from cassandra.query import BatchStatement
 from cassio.config import check_resolve_keyspace, check_resolve_session
 
-from .traverse import Node, Relation, traverse, atraverse
+from .traverse import Node, Relation, atraverse, traverse
 from .utils import batched
+
 
 class CassandraKnowledgeGraph:
     def __init__(
-            self,
-            node_table: str = "entities",
-            edge_table: str = "relationships",
-            session: Optional[Session] = None,
-            keyspace: Optional[str] = None,
-            apply_schema: bool = True,
+        self,
+        node_table: str = "entities",
+        edge_table: str = "relationships",
+        session: Optional[Session] = None,
+        keyspace: Optional[str] = None,
+        apply_schema: bool = True,
     ) -> None:
         """
         Create a Cassandra Knowledge Graph.
@@ -106,8 +107,8 @@ class CassandraKnowledgeGraph:
                             element.source.type,
                             element.target.name,
                             element.target.type,
-                            element.type
-                        )
+                            element.type,
+                        ),
                     )
                 else:
                     raise ValueError(f"Unsupported element type: {element}")
@@ -133,17 +134,17 @@ class CassandraKnowledgeGraph:
         An iterable over relations in the traversed sub-graph.
         """
         return traverse(
-            start = start,
-            edge_table = self._edge_table,
-            edge_source_name = "source_name",
-            edge_source_type = "source_type",
-            edge_target_name = "target_name",
-            edge_target_type = "target_type",
-            edge_type = "edge_type",
-            edge_filters = edge_filters,
-            steps = steps,
-            session = self._session,
-            keyspace = self._keyspace,
+            start=start,
+            edge_table=self._edge_table,
+            edge_source_name="source_name",
+            edge_source_type="source_type",
+            edge_target_name="target_name",
+            edge_target_type="target_type",
+            edge_type="edge_type",
+            edge_filters=edge_filters,
+            steps=steps,
+            session=self._session,
+            keyspace=self._keyspace,
         )
 
     async def atraverse(
@@ -164,15 +165,15 @@ class CassandraKnowledgeGraph:
         An iterable over relations in the traversed sub-graph.
         """
         return await atraverse(
-            start = start,
-            edge_table = self._edge_table,
-            edge_source_name = "source_name",
-            edge_source_type = "source_type",
-            edge_target_name = "target_name",
-            edge_target_type = "target_type",
-            edge_type = "edge_type",
-            edge_filters = edge_filters,
-            steps = steps,
-            session = self._session,
-            keyspace = self._keyspace,
+            start=start,
+            edge_table=self._edge_table,
+            edge_source_name="source_name",
+            edge_source_type="source_type",
+            edge_target_name="target_name",
+            edge_target_type="target_type",
+            edge_type="edge_type",
+            edge_filters=edge_filters,
+            steps=steps,
+            session=self._session,
+            keyspace=self._keyspace,
         )

--- a/knowledge_graph/prompt_templates/extraction.md
+++ b/knowledge_graph/prompt_templates/extraction.md
@@ -1,0 +1,41 @@
+# Knowledge Graph Instructions for GPT-4
+
+## 1. Overview
+You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.
+Try to capture as much information from the text as possible without sacrificing accuracy.
+Do not add any information that is not explicitly mentioned in the text.
+
+The aim is to achieve simplicity and clarity in the knowledge graph, making it accessible for a vast audience.
+
+- **Nodes** represent entities and concepts.
+- **Edges** represent relationships between entities or concepts.
+
+## 2. Labeling Nodes
+
+- **Node IDs**: Never utilize integers as node IDs. Node IDs should be names or human-readable identifiers found in the text.
+- **Node Types**: Ensure you use available node types for node types.
+
+## 3. Labeling Edges
+
+- **Edge Types**: Ensure you use available edge types for edge types.
+- **Edge Consistency**: Ensure the source and target of each edge are consistent with one of the defined patterns.
+
+## 4. Coreference Resolution
+- **Maintain Entity Consistency**: When extracting entities, it's vital to ensure consistency. If an entity, such as "John Doe", is mentioned multiple times in the text but is referred to by different names or pronouns (e.g., "Joe", "he") always use the most complete identifier for that entity throughout the knowledge graph. In this example, use "John Doe" as the entity ID.
+
+Remember, the knowledge graph should be coherent and easily understandable, so maintaining consistency in entity references is crucial.
+
+## 5. Strict Compliance
+Adhere to the rules strictly. Non-compliance will result in termination.
+
+## 6. Knowledge Schema
+
+Use the following knowledge schema when extracting information for the knowledge graph.
+
+### Node Types
+
+{node_types}
+
+### Relationship Patterns
+
+{relationship_patterns}

--- a/knowledge_graph/render.py
+++ b/knowledge_graph/render.py
@@ -1,22 +1,28 @@
 from typing import Iterable, Union
+
 import graphviz
 from langchain_community.graphs.graph_document import GraphDocument, Node
+
 
 def _node_label(node: Node) -> str:
     return f"{node.id} [{node.type}]"
 
+
 def print_graph_documents(graph_documents: Union[GraphDocument, Iterable[GraphDocument]]):
-  if isinstance(graph_documents, GraphDocument):
-     graph_documents = [graph_documents]
+    if isinstance(graph_documents, GraphDocument):
+        graph_documents = [graph_documents]
 
-  for doc in graph_documents:
-    for relation in doc.relationships:
-        source = relation.source
-        target = relation.target
-        type = relation.type
-        print(f"{_node_label(source)} -> {_node_label(target)}: {type}")
+    for doc in graph_documents:
+        for relation in doc.relationships:
+            source = relation.source
+            target = relation.target
+            type = relation.type
+            print(f"{_node_label(source)} -> {_node_label(target)}: {type}")
 
-def render_graph_documents(graph_documents: Union[GraphDocument, Iterable[GraphDocument]]) -> graphviz.Digraph:
+
+def render_graph_documents(
+    graph_documents: Union[GraphDocument, Iterable[GraphDocument]],
+) -> graphviz.Digraph:
     if isinstance(graph_documents, GraphDocument):
         graph_documents = [GraphDocument]
 
@@ -31,7 +37,7 @@ def render_graph_documents(graph_documents: Union[GraphDocument, Iterable[GraphD
         else:
             node_id = f"{len(nodes)}"
             nodes[node_key] = node_id
-            dot.node(node_id, label = _node_label(node))
+            dot.node(node_id, label=_node_label(node))
             return node_id
 
     for graph_document in graph_documents:

--- a/knowledge_graph/runnables.py
+++ b/knowledge_graph/runnables.py
@@ -20,6 +20,7 @@ QUERY_ENTITY_EXTRACT_PROMPT = (
 )
 
 
+# TODO: Use a knowledge schema when extracting entities, to get the right kinds of nodes.
 def extract_entities(
     llm: BaseChatModel,
     keyword_extraction_prompt: str = QUERY_ENTITY_EXTRACT_PROMPT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ description = ""
 authors = ["Ben Chambers <35960+bjchambers@users.noreply.github.com>"]
 readme = "README.md"
 packages = [{include = "knowledge_graph"}]
+include = [
+    { path = "knowledge_graph/prompt_templates/*.md", format = ["sdist", "wheel"] }
+]
+
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def llm() -> BaseChatModel:
     try:
         from langchain_openai import ChatOpenAI
 
-        model = ChatOpenAI(model_name="gpt-4")
+        model = ChatOpenAI(model_name="gpt-4-turbo", temperature=0.0)
         return model
     except ValueError:
         pytest.skip("Unable to create OpenAI model")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def llm() -> BaseChatModel:
     try:
         from langchain_openai import ChatOpenAI
 
-        model = ChatOpenAI(model_name="gpt-4-turbo", temperature=0.0)
+        model = ChatOpenAI(model_name="gpt-4-turbo-2024-04-09", temperature=0.0)
         return model
     except ValueError:
         pytest.skip("Unable to create OpenAI model")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,115 @@
+from precisely import assert_that, contains_exactly
+import pytest
+from knowledge_graph.extraction import KnowledgeSchema, KnowledgeSchemaExtractor, NodeSchema, RelationshipSchema
+from langchain_core.language_models import BaseChatModel
+from langchain_community.graphs.graph_document import Node, Relationship
+from langchain_core.documents import Document
+
+TEST_KNOWLEDGE_SCHEMA = KnowledgeSchema(
+    nodes = [
+        NodeSchema(type = "Institution",
+                   description="An institution, such as a business or university."),
+        NodeSchema(type = "Award",
+                   description="An award, such as the Nobel Prize or an Oscar."),
+        NodeSchema(type = "Person",
+                   description = "A person."),
+        NodeSchema(type = "Discipline",
+                   description = "An area of study, such as Biology or Chemistry."),
+        NodeSchema(type = "Nationality",
+                    description = "A nationality associated with people of a given country.")
+    ],
+    relationships = [
+        RelationshipSchema(
+            edge_type = "STUDIED",
+            source_types = ["Person"],
+            target_types = ["Discipline"],
+            description = "The source person studied the target discipline.",
+        ),
+        RelationshipSchema(
+            edge_type = "STUDIED_AT",
+            source_types = ["Person"],
+            target_types = ["Institution"],
+            description = "The source person studied at the target institution.",
+        ),
+        RelationshipSchema(
+            edge_type = "WORKED_AT",
+            source_types = ["Person"],
+            target_types = ["Institution"],
+            description = "The source person worked at the target institution.",
+        ),
+        RelationshipSchema(
+            edge_type = "RECEIVED",
+            source_types = ["Person"],
+            target_types = ["Award"],
+            description = "The source person received the target award.",
+        ),
+        RelationshipSchema(
+            edge_type = "HAS_NATIONALITY",
+            source_types = ["Person"],
+            target_types = ["Nationality"],
+            description = "The source person has the target nationality.",
+        ),
+        RelationshipSchema(
+            edge_type = "MARRIED_TO",
+            source_types = ["Person"],
+            target_types = ["Person"],
+            description = "The source is married to the target. Marriage is symmetric so the reverse relationship should also exist."
+        )
+    ],
+)
+
+@pytest.fixture(scope="session")
+def extractor(llm: BaseChatModel) -> KnowledgeSchemaExtractor:
+    return KnowledgeSchemaExtractor(
+        llm = llm,
+        schema = TEST_KNOWLEDGE_SCHEMA,
+    )
+
+
+def test_extraction(extractor: KnowledgeSchemaExtractor):
+    results = extractor.extract([Document(page_content="\n".join([
+        "Marie Curie, was a Polish and naturalised-French physicist and chemist who conducted pioneering research on radioactivity.",
+        "She was the first woman to win a Nobel Prize, the first person to win a Nobel Prize twice, and the only person to win a Nobel Prize in two scientific fields.",
+        "Her husband, Pierre Curie, was a co-winner of her first Nobel Prize, making them the first-ever married couple to win the Nobel Prize and launching the Curie family legacy of five Nobel Prizes.",
+        "She was, in 1906, the first woman to become a professor at the University of Paris."
+    ]))])
+
+    marie_curie = Node(id = "Marie Curie", type = "Person")
+    polish = Node(id = "Polish", type = "Nationality")
+    french = Node(id = "French", type = "Nationality")
+    physicist = Node(id = "Physicist", type = "Discipline")
+    chemist = Node(id = "Chemist", type = "Discipline")
+    nobel_prize = Node(id = "Nobel Prize", type = "Award")
+    pierre_curie = Node(id = "Pierre Curie", type = "Person")
+
+    # Annoyingly, the LLM seems to upper-case `of`. We probably need some instructions around
+    # putting things into standard title case, etc.
+    university_of_paris = Node(id = "University Of Paris", type = "Institution")
+
+    assert_that(
+        results[0].nodes,
+        contains_exactly(
+            marie_curie,
+            polish,
+            french,
+            physicist,
+            chemist,
+            nobel_prize,
+            pierre_curie,
+            university_of_paris,
+        )
+    )
+    assert_that(
+        results[0].relationships,
+        contains_exactly(
+            Relationship(source = marie_curie, target=polish, type="HAS_NATIONALITY"),
+            Relationship(source = marie_curie, target=french, type="HAS_NATIONALITY"),
+            Relationship(source = marie_curie, target=physicist, type="STUDIED"),
+            Relationship(source = marie_curie, target=chemist, type="STUDIED"),
+            Relationship(source = marie_curie, target=nobel_prize, type="RECEIVED"),
+            Relationship(source = pierre_curie, target=nobel_prize, type="RECEIVED"),
+            Relationship(source = marie_curie, target=university_of_paris, type="WORKED_AT"),
+            Relationship(source = marie_curie, target=pierre_curie, type="MARRIED_TO"),
+            Relationship(source = pierre_curie, target=marie_curie, type="MARRIED_TO"),
+        )
+    )

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,90 +1,109 @@
-from precisely import assert_that, contains_exactly
 import pytest
-from knowledge_graph.extraction import KnowledgeSchema, KnowledgeSchemaExtractor, NodeSchema, RelationshipSchema
-from langchain_core.language_models import BaseChatModel
 from langchain_community.graphs.graph_document import Node, Relationship
 from langchain_core.documents import Document
+from langchain_core.language_models import BaseChatModel
+from precisely import assert_that, contains_exactly
+
+from knowledge_graph.extraction import (
+    KnowledgeSchema,
+    KnowledgeSchemaExtractor,
+    NodeSchema,
+    RelationshipSchema,
+)
 
 TEST_KNOWLEDGE_SCHEMA = KnowledgeSchema(
-    nodes = [
-        NodeSchema(type = "Institution",
-                   description="An institution, such as a business or university."),
-        NodeSchema(type = "Award",
-                   description="An award, such as the Nobel Prize or an Oscar."),
-        NodeSchema(type = "Person",
-                   description = "A person."),
-        NodeSchema(type = "Discipline",
-                   description = "An area of study, such as Biology or Chemistry."),
-        NodeSchema(type = "Nationality",
-                    description = "A nationality associated with people of a given country.")
+    nodes=[
+        NodeSchema(
+            type="Institution", description="An institution, such as a business or university."
+        ),
+        NodeSchema(type="Award", description="An award, such as the Nobel Prize or an Oscar."),
+        NodeSchema(type="Person", description="A person."),
+        NodeSchema(
+            type="Discipline", description="An area of study, such as Biology or Chemistry."
+        ),
+        NodeSchema(
+            type="Nationality",
+            description="A nationality associated with people of a given country.",
+        ),
     ],
-    relationships = [
+    relationships=[
         RelationshipSchema(
-            edge_type = "STUDIED",
-            source_types = ["Person"],
-            target_types = ["Discipline"],
-            description = "The source person studied the target discipline.",
+            edge_type="STUDIED",
+            source_types=["Person"],
+            target_types=["Discipline"],
+            description="The source person studied the target discipline.",
         ),
         RelationshipSchema(
-            edge_type = "STUDIED_AT",
-            source_types = ["Person"],
-            target_types = ["Institution"],
-            description = "The source person studied at the target institution.",
+            edge_type="STUDIED_AT",
+            source_types=["Person"],
+            target_types=["Institution"],
+            description="The source person studied at the target institution.",
         ),
         RelationshipSchema(
-            edge_type = "WORKED_AT",
-            source_types = ["Person"],
-            target_types = ["Institution"],
-            description = "The source person worked at the target institution.",
+            edge_type="WORKED_AT",
+            source_types=["Person"],
+            target_types=["Institution"],
+            description="The source person worked at the target institution.",
         ),
         RelationshipSchema(
-            edge_type = "RECEIVED",
-            source_types = ["Person"],
-            target_types = ["Award"],
-            description = "The source person received the target award.",
+            edge_type="RECEIVED",
+            source_types=["Person"],
+            target_types=["Award"],
+            description="The source person received the target award.",
         ),
         RelationshipSchema(
-            edge_type = "HAS_NATIONALITY",
-            source_types = ["Person"],
-            target_types = ["Nationality"],
-            description = "The source person has the target nationality.",
+            edge_type="HAS_NATIONALITY",
+            source_types=["Person"],
+            target_types=["Nationality"],
+            description="The source person has the target nationality.",
         ),
         RelationshipSchema(
-            edge_type = "MARRIED_TO",
-            source_types = ["Person"],
-            target_types = ["Person"],
-            description = "The source is married to the target. Marriage is symmetric so the reverse relationship should also exist."
-        )
+            edge_type="MARRIED_TO",
+            source_types=["Person"],
+            target_types=["Person"],
+            description=(
+                "The source is married to the target."
+                "Marriage is symmetric so the reverse relationship should also exist."
+            ),
+        ),
     ],
 )
+
 
 @pytest.fixture(scope="session")
 def extractor(llm: BaseChatModel) -> KnowledgeSchemaExtractor:
     return KnowledgeSchemaExtractor(
-        llm = llm,
-        schema = TEST_KNOWLEDGE_SCHEMA,
+        llm=llm,
+        schema=TEST_KNOWLEDGE_SCHEMA,
     )
 
 
-def test_extraction(extractor: KnowledgeSchemaExtractor):
-    results = extractor.extract([Document(page_content="\n".join([
-        "Marie Curie, was a Polish and naturalised-French physicist and chemist who conducted pioneering research on radioactivity.",
-        "She was the first woman to win a Nobel Prize, the first person to win a Nobel Prize twice, and the only person to win a Nobel Prize in two scientific fields.",
-        "Her husband, Pierre Curie, was a co-winner of her first Nobel Prize, making them the first-ever married couple to win the Nobel Prize and launching the Curie family legacy of five Nobel Prizes.",
-        "She was, in 1906, the first woman to become a professor at the University of Paris."
-    ]))])
+MARIE_CURIE_SOURCE = """
+Marie Curie, was a Polish and naturalised-French physicist and chemist who
+conducted pioneering research on radioactivity. She was the first woman to win a
+Nobel Prize, the first person to win a Nobel Prize twice, and the only person to
+win a Nobel Prize in two scientific fields. Her husband, Pierre Curie, was a
+co-winner of her first Nobel Prize, making them the first-ever married couple to
+win the Nobel Prize and launching the Curie family legacy of five Nobel Prizes.
+She was, in 1906, the first woman to become a professor at the University of
+Paris.
+"""
 
-    marie_curie = Node(id = "Marie Curie", type = "Person")
-    polish = Node(id = "Polish", type = "Nationality")
-    french = Node(id = "French", type = "Nationality")
-    physicist = Node(id = "Physicist", type = "Discipline")
-    chemist = Node(id = "Chemist", type = "Discipline")
-    nobel_prize = Node(id = "Nobel Prize", type = "Award")
-    pierre_curie = Node(id = "Pierre Curie", type = "Person")
+
+def test_extraction(extractor: KnowledgeSchemaExtractor):
+    results = extractor.extract([Document(page_content=MARIE_CURIE_SOURCE)])
+
+    marie_curie = Node(id="Marie Curie", type="Person")
+    polish = Node(id="Polish", type="Nationality")
+    french = Node(id="French", type="Nationality")
+    physicist = Node(id="Physicist", type="Discipline")
+    chemist = Node(id="Chemist", type="Discipline")
+    nobel_prize = Node(id="Nobel Prize", type="Award")
+    pierre_curie = Node(id="Pierre Curie", type="Person")
 
     # Annoyingly, the LLM seems to upper-case `of`. We probably need some instructions around
     # putting things into standard title case, etc.
-    university_of_paris = Node(id = "University Of Paris", type = "Institution")
+    university_of_paris = Node(id="University Of Paris", type="Institution")
 
     assert_that(
         results[0].nodes,
@@ -97,19 +116,19 @@ def test_extraction(extractor: KnowledgeSchemaExtractor):
             nobel_prize,
             pierre_curie,
             university_of_paris,
-        )
+        ),
     )
     assert_that(
         results[0].relationships,
         contains_exactly(
-            Relationship(source = marie_curie, target=polish, type="HAS_NATIONALITY"),
-            Relationship(source = marie_curie, target=french, type="HAS_NATIONALITY"),
-            Relationship(source = marie_curie, target=physicist, type="STUDIED"),
-            Relationship(source = marie_curie, target=chemist, type="STUDIED"),
-            Relationship(source = marie_curie, target=nobel_prize, type="RECEIVED"),
-            Relationship(source = pierre_curie, target=nobel_prize, type="RECEIVED"),
-            Relationship(source = marie_curie, target=university_of_paris, type="WORKED_AT"),
-            Relationship(source = marie_curie, target=pierre_curie, type="MARRIED_TO"),
-            Relationship(source = pierre_curie, target=marie_curie, type="MARRIED_TO"),
-        )
+            Relationship(source=marie_curie, target=polish, type="HAS_NATIONALITY"),
+            Relationship(source=marie_curie, target=french, type="HAS_NATIONALITY"),
+            Relationship(source=marie_curie, target=physicist, type="STUDIED"),
+            Relationship(source=marie_curie, target=chemist, type="STUDIED"),
+            Relationship(source=marie_curie, target=nobel_prize, type="RECEIVED"),
+            Relationship(source=pierre_curie, target=nobel_prize, type="RECEIVED"),
+            Relationship(source=marie_curie, target=university_of_paris, type="WORKED_AT"),
+            Relationship(source=marie_curie, target=pierre_curie, type="MARRIED_TO"),
+            Relationship(source=pierre_curie, target=marie_curie, type="MARRIED_TO"),
+        ),
     )

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -4,6 +4,7 @@ from knowledge_graph.traverse import Node, Relation, atraverse, traverse
 
 from .conftest import DataFixture
 
+
 def test_traverse_empty(marie_curie: DataFixture) -> None:
     results = traverse(
         start=[],
@@ -13,6 +14,7 @@ def test_traverse_empty(marie_curie: DataFixture) -> None:
         keyspace=marie_curie.keyspace,
     )
     assert_that(results, contains_exactly())
+
 
 def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     results = traverse(
@@ -57,6 +59,7 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
     assert_that(results, contains_exactly(*expected))
 
+
 async def test_atraverse_empty(marie_curie: DataFixture) -> None:
     results = await atraverse(
         start=[],
@@ -66,6 +69,7 @@ async def test_atraverse_empty(marie_curie: DataFixture) -> None:
         keyspace=marie_curie.keyspace,
     )
     assert_that(results, contains_exactly())
+
 
 async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
     results = await atraverse(


### PR DESCRIPTION
These describe the schema for the knowledge graph to be extracted. Currently, they allow defining the types of nodes and relationships that can be extracted. We could extend this in the future to allow properties of nodes/edges to be extracted and merged, etc.

This uses a prompt loaded from `extraction.md` for easy iteration.