### PR TITLE
feat: vector search for finding nodes

### DIFF
--- a/knowledge_graph/cassandra_graph_store.py
+++ b/knowledge_graph/cassandra_graph_store.py
@@ -4,6 +4,7 @@ from cassandra.cluster import Session
 from langchain_community.graphs.graph_document import GraphDocument
 from langchain_community.graphs.graph_document import Node as LangChainNode
 from langchain_community.graphs.graph_store import GraphStore
+from langchain_core.embeddings import Embeddings
 from langchain_core.runnables import Runnable, RunnableLambda
 
 from knowledge_graph.knowledge_graph import CassandraKnowledgeGraph
@@ -27,6 +28,7 @@ class CassandraGraphStore(GraphStore):
         self,
         node_table: str = "entities",
         edge_table: str = "relationships",
+        text_embeddings: Optional[Embeddings] = None,
         session: Optional[Session] = None,
         keyspace: Optional[str] = None,
     ) -> None:
@@ -39,6 +41,7 @@ class CassandraGraphStore(GraphStore):
         self.graph = CassandraKnowledgeGraph(
             node_table=node_table,
             edge_table=edge_table,
+            text_embeddings=text_embeddings,
             session=session,
             keyspace=keyspace,
         )

--- a/knowledge_graph/extraction.py
+++ b/knowledge_graph/extraction.py
@@ -41,7 +41,11 @@ class KnowledgeSchemaExtractor:
         self._validator = KnowledgeSchemaValidator(schema)
         self.strict = strict
 
-        messages = [SystemMessagePromptTemplate(prompt = load_template("extraction.md", knowledge_schema_yaml=schema.to_yaml_str()))]
+        messages = [
+            SystemMessagePromptTemplate(
+                prompt=load_template("extraction.md", knowledge_schema_yaml=schema.to_yaml_str())
+            )
+        ]
 
         if examples:
             formatted = "\n\n".join(map(_format_example, examples))

--- a/knowledge_graph/render.py
+++ b/knowledge_graph/render.py
@@ -50,6 +50,7 @@ def render_graph_documents(
 
     return dot
 
+
 def render_knowledge_schema(knowledge_schema: KnowledgeSchema) -> graphviz.Digraph:
     dot = graphviz.Digraph()
 
@@ -59,8 +60,6 @@ def render_knowledge_schema(knowledge_schema: KnowledgeSchema) -> graphviz.Digra
     for r in knowledge_schema.relationships:
         for source in r.source_types:
             for target in r.target_types:
-                dot.edge(source, target,
-                         label = r.edge_type,
-                         tooltip=r.description)
+                dot.edge(source, target, label=r.edge_type, tooltip=r.description)
 
     return dot

--- a/knowledge_graph/schema_inference.py
+++ b/knowledge_graph/schema_inference.py
@@ -1,20 +1,28 @@
 from typing import Sequence, cast
+
 from langchain_core.documents import Document
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
 
 from knowledge_graph.knowledge_schema import KnowledgeSchema
 from knowledge_graph.templates import load_template
 
-class KnowledgeSchemaInferer():
+
+class KnowledgeSchemaInferer:
     def __init__(self, llm: BaseChatModel) -> None:
         prompt = load_template(
             "schema_inference.md",
         )
-        prompt = ChatPromptTemplate.from_messages([
-            SystemMessagePromptTemplate(prompt = load_template("schema_inference.md")),
-            HumanMessagePromptTemplate.from_template("Input: {input}")
-        ])
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate(prompt=load_template("schema_inference.md")),
+                HumanMessagePromptTemplate.from_template("Input: {input}"),
+            ]
+        )
         # TODO: Use "full" output so we can detect parsing errors?
         structured_llm = llm.with_structured_output(KnowledgeSchema)
         self._chain = prompt | structured_llm

--- a/knowledge_graph/traverse.py
+++ b/knowledge_graph/traverse.py
@@ -1,6 +1,6 @@
 import asyncio
 import threading
-from typing import Any, Iterable, NamedTuple, Optional, Sequence, Dict
+from typing import Any, Dict, Iterable, NamedTuple, Optional, Sequence
 
 from cassandra.cluster import PreparedStatement, ResponseFuture, Session
 from cassio.config import check_resolve_keyspace, check_resolve_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,9 +71,20 @@ class DataFixture:
         self.uid = secrets.token_hex(8)
         self.node_table = f"entities_{self.uid}"
         self.edge_table = f"relationships_{self.uid}"
+
+        text_embeddings = None
+        try:
+            from langchain_openai import OpenAIEmbeddings
+
+            text_embeddings = OpenAIEmbeddings()
+        except ValueError:
+            print("OpenAI not configured. Not embedding data.")
+        self.has_embeddings = text_embeddings is not None
+
         self.graph_store = CassandraGraphStore(
             node_table=self.node_table,
             edge_table=self.edge_table,
+            text_embeddings=text_embeddings,
             session=session,
             keyspace=keyspace,
         )

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,8 +1,10 @@
+import pytest
 from precisely import assert_that, contains_exactly
 
-from knowledge_graph.traverse import Node, Relation, atraverse, traverse
+from knowledge_graph.traverse import Node, Relation
 
 from .conftest import DataFixture
+
 
 def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     (result_nodes, result_edges) = marie_curie.graph_store.graph.subgraph(
@@ -47,3 +49,13 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     assert_that(result_edges, contains_exactly(*expected_edges))
     assert_that(result_nodes, contains_exactly(*expected_nodes))
 
+
+def test_fuzzy_search(marie_curie: DataFixture) -> None:
+    if not marie_curie.has_embeddings:
+        pytest.skip("Fuzzy search requires embeddings. Run with openai environment variables")
+    result_nodes = marie_curie.graph_store.graph.query_nearest_nodes(["Marie", "Poland"])
+    expected_nodes = [
+        Node(name="Marie Curie", type="Person"),
+        Node(name="Polish", type="Nationality", properties={"European": True}),
+    ]
+    assert_that(result_nodes, contains_exactly(*expected_nodes))

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -4,8 +4,6 @@ from precisely import assert_that, contains_exactly
 
 from knowledge_graph.schema_inference import KnowledgeSchemaInferer
 
-
-
 MARIE_CURIE_SOURCE = """
 Marie Curie, was a Polish and naturalised-French physicist and chemist who
 conducted pioneering research on radioactivity. She was the first woman to win a
@@ -24,11 +22,13 @@ def test_schema_inference(llm: BaseChatModel):
     results = schema_inferer.infer_schemas_from([Document(page_content=MARIE_CURIE_SOURCE)])[0]
 
     print(results.to_yaml_str())
-    assert_that([n.type for n in results.nodes], contains_exactly(
-        "person", "institution", "award", "nationality", "field"
-    ))
-    assert_that([r.edge_type for r in results.relationships], contains_exactly(
-        "won", "is_nationality_of", "works_at", "is_field_of"
-    ))
+    assert_that(
+        [n.type for n in results.nodes],
+        contains_exactly("person", "institution", "award", "nationality", "field"),
+    )
+    assert_that(
+        [r.edge_type for r in results.relationships],
+        contains_exactly("won", "is_nationality_of", "works_at", "is_field_of"),
+    )
 
     # We don't do more testing here since this is meant to attempt to infer things.

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -59,6 +59,7 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
     assert_that(results, contains_exactly(*expected))
 
+
 async def test_atraverse_empty(marie_curie: DataFixture) -> None:
     results = await atraverse(
         start=[],


### PR DESCRIPTION
This adds a method to the knowledge graph for doing similarity search to locate nodes. It doesn't create a LangChain runnable which uses this method yet, but that should be pretty easy to do inside a notebook or elsewhere.